### PR TITLE
fix `/lib/{schooner|server}/hoon` for zuse 412k

### DIFF
--- a/desk/lib/mip.hoon
+++ b/desk/lib/mip.hoon
@@ -1,1 +1,55 @@
-../../base-dev/lib/mip.hoon
+|%
+++  mip                                                 ::  map of maps
+  |$  [kex key value]
+  (map kex (map key value))
+::
+++  bi                                                  ::  mip engine
+  =|  a=(map * (map))
+  |@
+  ++  del
+    |*  [b=* c=*]
+    =+  d=(~(gut by a) b ~)
+    =+  e=(~(del by d) c)
+    ?~  e
+      (~(del by a) b)
+    (~(put by a) b e)
+  ::
+  ++  get
+    |*  [b=* c=*]
+    =>  .(b `_?>(?=(^ a) p.n.a)`b, c `_?>(?=(^ a) ?>(?=(^ q.n.a) p.n.q.n.a))`c)
+    ^-  (unit _?>(?=(^ a) ?>(?=(^ q.n.a) q.n.q.n.a)))
+    (~(get by (~(gut by a) b ~)) c)
+  ::
+  ++  got
+    |*  [b=* c=*]
+    (need (get b c))
+  ::
+  ++  gut
+    |*  [b=* c=* d=*]
+    (~(gut by (~(gut by a) b ~)) c d)
+  ::
+  ++  has
+    |*  [b=* c=*]
+    !=(~ (get b c))
+  ::
+  ++  key
+    |*  b=*
+    ~(key by (~(gut by a) b ~))
+  ::
+  ++  put
+    |*  [b=* c=* d=*]
+    %+  ~(put by a)  b
+    %.  [c d]
+    %~  put  by
+    (~(gut by a) b ~)
+  ::
+  ++  tap
+    ::NOTE  naive turn-based implementation find-errors ):
+    =<  $
+    =+  b=`_?>(?=(^ a) *(list [x=_p.n.a _?>(?=(^ q.n.a) [y=p v=q]:n.q.n.a)]))`~
+    |.  ^+  b
+    ?~  a
+      b
+    $(a r.a, b (welp (turn ~(tap by q.n.a) (lead p.n.a)) $(a l.a)))
+  --
+--

--- a/desk/lib/rudder.hoon
+++ b/desk/lib/rudder.hoon
@@ -272,7 +272,7 @@
   (fall (rush url ;~(plug apat:de-purl:html yque:de-purl:html)) [[~ ~] ~])
 ::
 ++  press  ::  manx to octs
-  (cork en-xml:html as-octs:mimes:html)
+  (cork en-xml:html as-octt:mimes:html)
 ::
 ++  spout  ::  build full response cards
   |=  [eyre-id=@ta simple-payload:http]
@@ -283,4 +283,3 @@
       [%give %kick ~[path] ~]
   ==
 --
-

--- a/desk/lib/schooner.hoon
+++ b/desk/lib/schooner.hoon
@@ -196,7 +196,7 @@
     :-  :-  http-status
         %+  weld  headers
         ['content-type'^'application/json']~
-    `(as-octt:mimes:html (en-json:html j.resource))
+    `(as-octt:mimes:html (trip (en:json:html j.resource)))
     ::
       %manx
     :-  :-  http-status

--- a/desk/lib/server.hoon
+++ b/desk/lib/server.hoon
@@ -19,7 +19,7 @@
 ++  json-to-octs
   |=  jon=json
   ^-  octs
-  (as-octt:mimes:html (en-json:html jon))
+  (as-octt:mimes:html (trip (en:json:html jon)))
 ::
 ++  app
   |%


### PR DESCRIPTION
Update `/lib/schooner/hoon` and `/lib/server/hoon` to use `+en:json:html` instead of `+en-json:html` to accommodate zuse 412K [breaking changes](https://gist.github.com/pkova/6ddc65aa2ca192d0efa8667a36bac177#breaking-changes).

A production example using the updated library files can be found at [sidnym-ladrut/elogin](https://github.com/sidnym-ladrut/elogin).